### PR TITLE
Read gamma contract logs from stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Commands:
                    example: gamma-cli upgrade-server
                             gamma-cli upgrade-server -env experimental
 
+  logs             streams logs from gamma that are printed by smart contract to stdout (i.e. println())
+
   version          print gamma-cli and Gamma server versions
 
   help             print this help screen

--- a/docker.go
+++ b/docker.go
@@ -152,7 +152,7 @@ func showLogs(requiredOptions []string) {
 	verifyDockerInstalled(dockerOptions, dockerOptions.dockerRegistryTagsUrl)
 
 	cmd := exec.Command("docker", "logs", "-f", "--tail=20", dockerOptions.containerName)
-	stdout, err := cmd.StdoutPipe()
+	stdout, err := cmd.StderrPipe() // println() and print() go to stderr
 	if err != nil {
 		die("could not read gamma server docker logs: %s", err)
 	}
@@ -163,11 +163,7 @@ func showLogs(requiredOptions []string) {
 
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
-		line := scanner.Text()
-
-		if testGammaLogLine(line)  {
-			fmt.Println(line)
-		}
+		fmt.Println(scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
 		die("error reading gamma server docker logs: %s", err)
@@ -329,10 +325,4 @@ func createDockerNetwork() error {
 
 func prismEnabled() bool {
 	return !*flagNoUi
-}
-
-func testGammaLogLine(line string) bool {
-	return !strings.Contains(line, "info ") && !strings.HasPrefix(line, "error ") &&
-		!strings.HasPrefix(line, "debug ") && !strings.HasPrefix(line, "\t") &&
-		!strings.HasPrefix(line, "] ")
 }

--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ var commands = map[string]*command{
 		requiredOptions: nil,
 	},
 	"logs": {
-		desc: "streams logs from gamma that are printed by smart contract to stdout (i.e. fmt.Println)",
+		desc: "streams logs from gamma that are printed by smart contract to stdout (i.e. println())",
 		handler: showLogs,
 		sort: 9,
 		example: "gamma-cli logs",


### PR DESCRIPTION
`fmt` package was banned by Eran, so we have to rely on `println` and `print` which go to stderr. It means that `testGammaLogLine` functions becomes obsolete.